### PR TITLE
Introduce command parents

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ class HelloCommand extends ApheleiaCli\Command
 
 $registry = new ApheleiaCli\CommandRegistry();
 
-$registry->namespace('example', 'Implements example command.', function($scopedRegistry) {
+$registry->group('example', 'Implements example command.', function($scopedRegistry) {
     $scopedRegistry->add(new HelloCommand());
 });
 
@@ -60,7 +60,7 @@ Alternatively, you might want to define a command on the fly:
 ```php
 $registry = new ApheleiaCli\CommandRegistry();
 
-$registry->namespace('example', 'Implements example command.', function($scopedRegistry) {
+$registry->group('example', 'Implements example command.', function($scopedRegistry) {
     $command = (new ApheleiaCli\Command())
         ->setName('hello')
         ->setDescription('Prints a greeting.')
@@ -122,7 +122,7 @@ class HelloCommand extends ApheleiaCli\Command
 // InvokerBackedInvocationStrategy calls command handlers using the php-di/invoker package.
 $registry = new ApheleiaCli\CommandRegistry(new ApheleiaCli\InvokerBackedInvocationStrategy());
 
-$registry->namespace('example', 'Implements example command.', function($scopedRegistry) {
+$registry->group('example', 'Implements example command.', function($scopedRegistry) {
     $scopedRegistry->add(new HelloCommand());
 });
 
@@ -134,7 +134,7 @@ There is also an alternate syntax:
 ```php
 $registry = new ApheleiaCli\CommandRegistry();
 
-$registry->namespace('example', 'Implements example command.', function($scopedRegistry) {
+$registry->group('example', 'Implements example command.', function($scopedRegistry) {
     $scopedRegistry->command('hello <name> [--type=<type>]', function($args, $assoc_args) {
         list($name) = $args;
 

--- a/README.md
+++ b/README.md
@@ -19,37 +19,37 @@ The intended primary approach is to write self contained command classes:
 ```php
 class HelloCommand extends ApheleiaCli\Command
 {
-	public function configure(): void
-	{
-		$this->setName('hello')
-			->setDescription('Prints a greeting.')
-			->addArgument(
-				(new ApheleiaCli\Argument('name'))
-					->setDescription('The name of the person to greet.')
-			)
-			->addOption(
-				(new ApheleiaCli\Option('type'))
-					->setDescription('Whether or not to greet the person with success or error.')
-					->setDefault('success')
-					->setOptions('success', 'error')
-			)
-			->setUsage("## EXAMPLES\n\n\twp example hello newman")
-			->setWhen('after_wp_load');
-	}
+    public function configure(): void
+    {
+        $this->setName('hello')
+            ->setDescription('Prints a greeting.')
+            ->addArgument(
+                (new ApheleiaCli\Argument('name'))
+                    ->setDescription('The name of the person to greet.')
+            )
+            ->addOption(
+                (new ApheleiaCli\Option('type'))
+                    ->setDescription('Whether or not to greet the person with success or error.')
+                    ->setDefault('success')
+                    ->setOptions('success', 'error')
+            )
+            ->setUsage("## EXAMPLES\n\n\twp example hello newman")
+            ->setWhen('after_wp_load');
+    }
 
-	public function handle($args, $assoc_args)
-	{
-		list($name) = $args;
+    public function handle($args, $assoc_args)
+    {
+        list($name) = $args;
 
-		$type = $assoc_args['type'];
-		WP_CLI::$type("Hello, $name!");
-	}
+        $type = $assoc_args['type'];
+        WP_CLI::$type("Hello, $name!");
+    }
 }
 
 $registry = new ApheleiaCli\CommandRegistry();
 
 $registry->namespace('example', 'Implements example command.', function($scopedRegistry) {
-	$scopedRegistry->add(new HelloCommand());
+    $scopedRegistry->add(new HelloCommand());
 });
 
 $registry->initialize();
@@ -61,29 +61,29 @@ Alternatively, you might want to define a command on the fly:
 $registry = new ApheleiaCli\CommandRegistry();
 
 $registry->namespace('example', 'Implements example command.', function($scopedRegistry) {
-	$command = (new ApheleiaCli\Command())
-		->setName('hello')
-		->setDescription('Prints a greeting.')
-		->addArgument(
-			(new ApheleiaCli\Argument('name'))
-				->setDescription('The name of the person to greet.')
-		)
-		->addOption(
-			(new ApheleiaCli\Option('type'))
-				->setDescription('Whether or not to greet the person with success or error.')
-				->setDefault('success')
-				->setOptions('success', 'error')
-		)
-		->setUsage("## EXAMPLES\n\n\twp example hello newman")
-		->setWhen('after_wp_load')
-		->setHandler(function($args, $assoc_args) {
-			list($name) = $args;
+    $command = (new ApheleiaCli\Command())
+        ->setName('hello')
+        ->setDescription('Prints a greeting.')
+        ->addArgument(
+            (new ApheleiaCli\Argument('name'))
+                ->setDescription('The name of the person to greet.')
+        )
+        ->addOption(
+            (new ApheleiaCli\Option('type'))
+                ->setDescription('Whether or not to greet the person with success or error.')
+                ->setDefault('success')
+                ->setOptions('success', 'error')
+        )
+        ->setUsage("## EXAMPLES\n\n\twp example hello newman")
+        ->setWhen('after_wp_load')
+        ->setHandler(function($args, $assoc_args) {
+            list($name) = $args;
 
-			$type = $assoc_args['type'];
-			WP_CLI::$type("Hello, $name!");
-		});
+            $type = $assoc_args['type'];
+            WP_CLI::$type("Hello, $name!");
+        });
 
-	$scopedRegistry->add($command);
+    $scopedRegistry->add($command);
 });
 
 $registry->initialize();
@@ -94,36 +94,36 @@ You can also set a custom handler invocation strategy:
 ```php
 class HelloCommand extends ApheleiaCli\Command
 {
-	public function configure(): void
-	{
-		$this->setName('hello')
-			->setDescription('Prints a greeting.')
-			->addArgument(
-				(new ApheleiaCli\Argument('name'))
-					->setDescription('The name of the person to greet.')
-			)
-			->addOption(
-				(new ApheleiaCli\Option('type'))
-					->setDescription('Whether or not to greet the person with success or error.')
-					->setDefault('success')
-					->setOptions('success', 'error')
-			)
-			->setUsage("## EXAMPLES\n\n\twp example hello newman")
-			->setWhen('after_wp_load');
-	}
+    public function configure(): void
+    {
+        $this->setName('hello')
+            ->setDescription('Prints a greeting.')
+            ->addArgument(
+                (new ApheleiaCli\Argument('name'))
+                    ->setDescription('The name of the person to greet.')
+            )
+            ->addOption(
+                (new ApheleiaCli\Option('type'))
+                    ->setDescription('Whether or not to greet the person with success or error.')
+                    ->setDefault('success')
+                    ->setOptions('success', 'error')
+            )
+            ->setUsage("## EXAMPLES\n\n\twp example hello newman")
+            ->setWhen('after_wp_load');
+    }
 
-	// No more $args and $assoc_args - ask for command params by name.
-	public function handle($name, $type)
-	{
-		WP_CLI::$type("Hello, $name!");
-	}
+    // No more $args and $assoc_args - ask for command params by name.
+    public function handle($name, $type)
+    {
+        WP_CLI::$type("Hello, $name!");
+    }
 }
 
 // InvokerBackedInvocationStrategy calls command handlers using the php-di/invoker package.
 $registry = new ApheleiaCli\CommandRegistry(new ApheleiaCli\InvokerBackedInvocationStrategy());
 
 $registry->namespace('example', 'Implements example command.', function($scopedRegistry) {
-	$scopedRegistry->add(new HelloCommand());
+    $scopedRegistry->add(new HelloCommand());
 });
 
 $registry->initialize();
@@ -135,21 +135,21 @@ There is also an alternate syntax:
 $registry = new ApheleiaCli\CommandRegistry();
 
 $registry->namespace('example', 'Implements example command.', function($scopedRegistry) {
-	$scopedRegistry->command('hello <name> [--type=<type>]', function($args, $assoc_args) {
-		list($name) = $args;
+    $scopedRegistry->command('hello <name> [--type=<type>]', function($args, $assoc_args) {
+        list($name) = $args;
 
-		$type = $assoc_args['type'];
-		WP_CLI::$type("Hello, $name!");
-	})->descriptions('Prints a greeting.', [
-		'name' => 'The name of the person to greet.',
-		'--type' => 'Whether or not to greet the person with success or error.',
-	])->defaults([
-		'--type' => 'success',
-	])->options([
-		'--type' => ['success', 'error'],
-	])->usage(
-		"## EXAMPLES\n\n\twp example hello newman"
-	)->when('after_wp_load');
+        $type = $assoc_args['type'];
+        WP_CLI::$type("Hello, $name!");
+    })->descriptions('Prints a greeting.', [
+        'name' => 'The name of the person to greet.',
+        '--type' => 'Whether or not to greet the person with success or error.',
+    ])->defaults([
+        '--type' => 'success',
+    ])->options([
+        '--type' => ['success', 'error'],
+    ])->usage(
+        "## EXAMPLES\n\n\twp example hello newman"
+    )->when('after_wp_load');
 });
 
 $registry->initialize();
@@ -161,11 +161,11 @@ In my opinion, this syntax shines when used for simpler command definitions alon
 $registry = new ApheleiaCli\CommandRegistry(new ApheleiaCli\InvokerBackedInvocationStrategy());
 
 $registry->command('example hello <name> [--type=<type>]', function($name, $type = 'success') {
-	if (! in_array($type, ['success', 'error'], true)) {
-		$type = 'success';
-	}
+    if (! in_array($type, ['success', 'error'], true)) {
+        $type = 'success';
+    }
 
-	WP_CLI::$type("Hello, $name!");
+    WP_CLI::$type("Hello, $name!");
 });
 
 $registry->initialize();

--- a/src/Command.php
+++ b/src/Command.php
@@ -41,14 +41,14 @@ class Command
     protected $name;
 
     /**
-     * @var string|null
-     */
-    protected $namespace;
-
-    /**
      * @var array<string, Flag|Option>
      */
     protected $options = [];
+
+    /**
+     * @var ?Command
+     */
+    protected $parent;
 
     /**
      * @var string|null
@@ -186,7 +186,13 @@ class Command
             throw new InvalidArgumentException('Command name must be non-empty string');
         }
 
-        return $this->namespace ? "{$this->namespace} {$this->name}" : $this->name;
+        $name = $this->name;
+
+        if ($this->parent instanceof Command) {
+            $name = "{$this->parent->getName()} {$name}";
+        }
+
+        return $name;
     }
 
     /**
@@ -280,9 +286,9 @@ class Command
         return $this;
     }
 
-    public function setNamespace(string $namespace): self
+    public function setParent(?Command $parent): self
     {
-        $this->namespace = $namespace;
+        $this->parent = $parent;
 
         return $this;
     }

--- a/src/CommandParser.php
+++ b/src/CommandParser.php
@@ -31,11 +31,7 @@ class CommandParser implements CommandParserInterface
         }
 
         $command = new Command();
-        $command->setName(array_pop($name));
-
-        if (! empty($name)) {
-            $command->setNamespace(implode(' ', $name));
-        }
+        $command->setName(implode(' ', $name));
 
         while (is_string($token)) {
             if ($this->isArgument($token)) {

--- a/src/CommandRegistry.php
+++ b/src/CommandRegistry.php
@@ -24,9 +24,9 @@ class CommandRegistry
     protected $commandParser;
 
     /**
-     * @var list<string>
+     * @var ?Command
      */
-    protected $groups = [];
+    protected $currentGroupParent;
 
     /**
      * @var InvocationStrategyInterface
@@ -60,8 +60,8 @@ class CommandRegistry
 
     public function add(Command $command): Command
     {
-        if (! empty($this->groups)) {
-            $command->setNamespace(implode(' ', $this->groups));
+        if ($this->currentGroupParent instanceof Command) {
+            $command->setParent($this->currentGroupParent);
         }
 
         $name = $command->getName();
@@ -122,11 +122,12 @@ class CommandRegistry
 
         $preCallbackCommandCount = count($this->registeredCommands);
 
-        $this->groups[] = $group;
+        $previousGroupParent = $this->currentGroupParent;
+        $this->currentGroupParent = $command;
 
         $callback($this);
 
-        array_pop($this->groups);
+        $this->currentGroupParent = $previousGroupParent;
 
         if (
             ! $this->allowChildlessGroups

--- a/tests/CommandRegistryTest.php
+++ b/tests/CommandRegistryTest.php
@@ -4,12 +4,8 @@ declare(strict_types=1);
 
 namespace ApheleiaCli\Tests;
 
-use ApheleiaCli\Argument;
 use ApheleiaCli\Command;
 use ApheleiaCli\CommandRegistry;
-use ApheleiaCli\Flag;
-use ApheleiaCli\NamespaceIdentifier;
-use ApheleiaCli\Option;
 use ApheleiaCli\WpCliAdapterInterface;
 use Closure;
 use PHPUnit\Framework\Constraint\IsType;
@@ -171,92 +167,6 @@ class CommandRegistryTest extends TestCase
 
         $registry->command('command <arg> [--option=<option>]', function () {
         });
-
-        $registry->initializeImmediately();
-    }
-
-    public function testInitializeImmediatelyWithAllOptionsConfigured()
-    {
-        $wpCliAdapterMock = $this->createMock(WpCliAdapterInterface::class);
-        $wpCliAdapterMock
-            ->expects($this->once())
-            ->method('isWpCli')
-            ->willReturn(true);
-        $wpCliAdapterMock
-            ->expects($this->exactly(2))
-            ->method('addCommand')
-            ->withConsecutive(
-                [
-                    'group',
-                    NamespaceIdentifier::class,
-                    [
-                        'shortdesc' => 'Group description',
-                    ]
-                ],
-                [
-                    'group command',
-                    $this->isInstanceOf(Closure::class),
-                    $this->callback(function ($subject) {
-                        return is_array($subject)
-                            && array_key_exists('shortdesc', $subject)
-                            && 'A description string' === $subject['shortdesc']
-                            && array_key_exists('synopsis', $subject)
-                            && [
-                                [
-                                    'type' => 'positional',
-                                    'name' => 'arg',
-                                    'optional' => false,
-                                    'repeating' => false,
-                                ],
-                                [
-                                    'type' => 'flag',
-                                    'name' => 'flag',
-                                    'optional' => true,
-                                    'repeating' => false,
-                                ],
-                                [
-                                    'type' => 'assoc',
-                                    'name' => 'opt',
-                                    'optional' => true,
-                                    'repeating' => false,
-                                ],
-                            ] === $subject['synopsis']
-                            && array_key_exists('longdesc', $subject)
-                            && 'A usage string' === $subject['longdesc']
-                            && array_key_exists('before_invoke', $subject)
-                            && $subject['before_invoke'] instanceof Closure
-                            && array_key_exists('after_invoke', $subject)
-                            && $subject['after_invoke'] instanceof Closure
-                            && array_key_exists('when', $subject)
-                            && 'when-string' === $subject['when'];
-                    })
-                ],
-            );
-
-        $registry = new CommandRegistry(null, null, $wpCliAdapterMock);
-
-        $registry->group(
-            'group',
-            'Group description',
-            function (CommandRegistry $registry) {
-                $registry->add(
-                    (new Command())
-                        ->setName('command')
-                        ->addArgument(new Argument('arg'))
-                        ->addFlag(new Flag('flag'))
-                        ->addOption(new Option('opt'))
-                        ->setDescription('A description string')
-                        ->setUsage('A usage string')
-                        ->setBeforeInvokeCallback(function () {
-                        })
-                        ->setAfterInvokeCallback(function () {
-                        })
-                        ->setWhen('when-string')
-                        ->setHandler(function () {
-                        })
-                );
-            }
-        );
 
         $registry->initializeImmediately();
     }

--- a/tests/CommandRegistryTest.php
+++ b/tests/CommandRegistryTest.php
@@ -33,27 +33,33 @@ class CommandRegistryTest extends TestCase
     {
         $one = (new Command())->setName('one');
         $two = (new Command())->setName('two');
+        $three = (new Command())->setName('three');
+        $four = (new Command())->setName('four');
 
         $registry = new CommandRegistry();
 
+        $registry->add($one);
+
         $registry->group(
-            'group-one',
+            'first',
             'description',
-            function (CommandRegistry $registry) use ($one, $two) {
-                $registry->add($one);
+            function (CommandRegistry $registry) use ($two, $three) {
+                $registry->add($two);
 
                 $registry->group(
-                    'group-two',
+                    'second',
                     'description',
-                    function (CommandRegistry $registry) use ($two) {
-                        $registry->add($two);
+                    function (CommandRegistry $registry) use ($three) {
+                        $registry->add($three);
                     }
                 );
             }
         );
 
-        $this->assertSame('group-one one', $one->getName());
-        $this->assertSame('group-one group-two two', $two->getName());
+        $this->assertSame('one', $one->getName());
+        $this->assertSame('first two', $two->getName());
+        $this->assertSame('first second three', $three->getName());
+        $this->assertSame('four', $four->getName());
     }
 
     public function testCommand()

--- a/tests/CommandTest.php
+++ b/tests/CommandTest.php
@@ -215,11 +215,26 @@ class CommandTest extends TestCase
         $command->getName();
     }
 
-    public function testGetNameWithNamespace()
+    public function testGetNameWithMultipleAncestors()
     {
-        $command = (new Command())->setName('irrelevant')->setNamespace('also-irrelevant');
+        $command = (new Command())->setName('command');
+        $parent = (new Command())->setName('parent');
+        $grandparent = (new Command())->setName('grandparent');
 
-        $this->assertSame('also-irrelevant irrelevant', $command->getName());
+        $command->setParent($parent);
+        $parent->setParent($grandparent);
+
+        $this->assertSame('grandparent parent command', $command->getName());
+    }
+
+    public function testGetNameWithParent()
+    {
+        $command = (new Command())->setName('command');
+        $parent = (new Command())->setName('parent');
+
+        $command->setParent($parent);
+
+        $this->assertSame('parent command', $command->getName());
     }
 
     public function testGetSynopsis()
@@ -272,5 +287,19 @@ class CommandTest extends TestCase
                 'repeating' => false,
             ],
         ], $command->getSynopsis());
+    }
+
+    public function testParentCanBeUnset()
+    {
+        $command = (new Command())->setName('command');
+        $parent = (new Command())->setName('parent');
+
+        $command->setParent($parent);
+
+        $this->assertSame('parent command', $command->getName());
+
+        $command->setParent(null);
+
+        $this->assertSame('command', $command->getName());
     }
 }


### PR DESCRIPTION
Adds the ability to have a parent/child relationship between commands.

Improves the previous namespace behavior. Namespace was not previously live - the actual namespace command instance could be modified and the namespace would not update with it.

Additionally this pr modifies the registry namespace method only register a namespace command and no children.

The previous behavior of the namespace method is moved a new group method.